### PR TITLE
Updates for Auto DQM (TPC) Plotter

### DIFF
--- a/python/dqmtools/dqmplots/tpc_plots.py
+++ b/python/dqmtools/dqmplots/tpc_plots.py
@@ -137,6 +137,10 @@ def plot_TPC_adc_map(df_dict,det_keys,ele,plane,
         df_tmp = df_tmp.reset_index()
         df_all.append(df_tmp)
 
+    if len(df_all)==0: 
+        print(f"No element {ele} (element_id={element_id}) found.")
+        return empty_plot()
+
     df_tmp = pd.concat(df_all,ignore_index=True)
 
     df_tmp["timestamps_trg_sub"] = df_tmp.apply(lambda x: x.timestamps.astype(np.int64) - x.trigger_timestamp_dts,axis=1)

--- a/scripts/dqm_plotter.py
+++ b/scripts/dqm_plotter.py
@@ -23,9 +23,9 @@ import click
 @click.option('--imgtype', default='svg', help='Type of image to write')
 @click.option('--component',default=None, help='specific component to plot')
 @click.option('--plane',default=None, help='specific plane to plot')
-@click.option('--hd/--vd', default=True, help='Whether we are running HD (or VD) (default: "HD")')
+#@click.option('--hd/--vd', default=True, help='Whether we are running HD (or VD) (default: "HD")')
 
-def main(input_data, output_dir, nworkers, nskip, nrecords, imgtype, component, plane, hd):
+def main(input_data, output_dir, nworkers, nskip, nrecords, imgtype, component, plane):
 
     filename = input_data
     if(os.path.isdir(input_data)):
@@ -66,35 +66,37 @@ def main(input_data, output_dir, nworkers, nskip, nrecords, imgtype, component, 
         pd.set_option('display.max_columns', None)
         print(df_dict["trh"])
 
-        if(hd):
-            tpc_det_key="detd_kHD_TPC_kWIBEth"
-        else:
-            tpc_det_key="detd_kVD_BottomTPC_kWIBEth"
+        index = df_dict["trh"].index[0]
+
+        det_keys = [ key for key in df_dict if key.startswith('detw') and 'TPC' in key ]
+
+        hd = any("kHD" in k for k in det_keys) #else, vd
+        
         offset=True
         
         if plane is not None:
             planes = [ int(plane) ]
         else:
             planes = [0, 1, 2]
-            
+
+        element_ids = []
         if component is not None:
-            elements = [ int(component) ]
+            element_ids = [ int(component) ]
         else:
             if(hd):
-                elements = [1,2,3,4]
+                element_ids = [1,2,3,4]
             else:
-                elements = [4,5]
+                element_ids = [2,3,4,5]
 
+        element_type="APA" if hd else "CRP"
+
+        elements = [ f'{element_type}{i}' for i in element_ids ]
+                
         myplanes = []
         for el in elements:
             for plane in planes:
                 myplanes.append((el,plane))
 
-        #planes = []
-        #for apa in ["APA2"]:
-        #    for plane in [0,1,2]:
-        #        planes.append((apa,plane))
-        
         df_dict["trh"]['trigger_time_cern'] = pd.to_datetime(df_dict["trh"]['trigger_time'])
         df_dict['trh']['trigger_time_cern'] = df_dict['trh']['trigger_time_cern'].dt.tz_convert('Europe/Zurich')
         trigger_timestamp = df_dict["trh"]["trigger_time"].iloc[0]
@@ -105,22 +107,22 @@ def main(input_data, output_dir, nworkers, nskip, nrecords, imgtype, component, 
             trigger_types_str = trigger_types_str + trigtype.name[1:] + ","
         trigger_types_str=trigger_types_str[:-1]+")"
         
-        if tpc_det_key not in df_dict.keys():
-            print("No tpc det waveforms in file.")
-            return None
-        
-        def make_adc_map_fig(apa,plane):
-            df_tmp, index = dfc.select_record(df_dict[tpc_det_key])
-            df_tmp= df_tmp.reset_index()
-            if(len(df_tmp)==0):
-                return "NO-DATA-FOUND"
-            fig = plot_WIBEth_adc_map(df_dict,tpc_det_key,apa,plane,
-                                      offset=True,make_static=True,make_tp_overlay=False,
-                                      orientation="vertical",colorscale='plasma',color_range=(-256,256))
-            print(f"Figure for Element {apa} plane {plane} processed...")
-            fig.update_layout(title=dict(text=f"Run {index.run}, Trigger {index.trigger}, {apa} Plane {plane}<br><sup>Trigger Type {trigger_types_str}, {trigger_timestamp_cern} (CERN)</sup>", font=dict(size=24) ) )
-            fig.write_image(f"{output_dir}/EventDisplay_run{index.run}_trigger{index.trigger}_seq{index.sequence}_{apa}_plane{plane}.{imgtype}", scale=3)
-            return f"EventDisplay_run{index.run}_trigger{index.trigger}_seq{index.sequence}_{apa}_plane{plane}.{imgtype}"
+        def make_adc_map_fig(element,plane):
+            fig = plot_TPC_adc_map(df_dict=df_dict, det_keys=det_keys,
+                                   plane=plane, ele=element,
+                                   make_static=True,
+                                   offset=offset,
+                                   make_tp_overlay=False,
+                                   orientation='vertical',
+                                   colorscale='plasma',
+                                   color_range=(-256,256),
+                                   run=index[0],
+                                   trigger=index[1],
+                                   seq=index[2])
+            print(f"Figure for Element {element} plane {plane} processed...")
+            fig.update_layout(title=dict(text=f"Run {int(index[0])}, Trigger {int(index[1])}, {element} Plane {plane}<br><sup>Trigger Type {trigger_types_str}, {trigger_timestamp_cern} (CERN)</sup>", font=dict(size=24) ) )
+            fig.write_image(f"{output_dir}/EventDisplay_run{int(index[0])}_trigger{int(index[1])}_seq{int(index[2])}_{element}_plane{plane}.{imgtype}", scale=3)
+            return f"EventDisplay_run{int(index[0])}_trigger{int(index[1])}_seq{int(index[2])}_{element}_plane{plane}.{imgtype}"
         
         with concurrent.futures.ThreadPoolExecutor(max_workers=nworkers) as executor:
             future_p = {executor.submit(make_adc_map_fig,


### PR DESCRIPTION
Updates to the dqm_plotter.py script, which makes event display maps by Element (APA or CRP) and by plane. Uses the new common WIB/TDE interface in tpc_plots.py, and now will auto-recognize HD or VD, so that is no longer needed as an option.

Can test by running:
```
dqm_plotter.py --imgtype pdf /nfs/rscratch/np04daq/DQM_DATA/NP02/np02vd_raw_run039048_0753_df-s04-d0_dw_0_20250826T021012.hdf5 temp_dir/
```